### PR TITLE
feat: added raced retry method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,182 @@
 # Retry
 
-A npm package for easily adding retry to fetch calls.
+A npm package for easily adding retry to fetch calls with adaptive timeout and concurrent retry strategies.
 
 ## Getting Started
 
 Install the [npm package](@dataforsyningen/retry):
 
-```
+```sh
 npm install @dataforsyningen/retry
 ```
 
 Import the options and functions you need, for instance:
 
+```javascript
+import { retryOptions, fetchWithRetry, fetchWithRacedRetries } from '@dataforsyningen/retry/index.js'
 ```
-import { retryOptions, fetchWithRetry } from '@dataforsyningen/retry/index.js'
+
+## Available Functions
+
+### `fetchWithRetry(url, options)`
+
+Sequential retry strategy that waits for each attempt to complete or timeout before starting the next one.
+
+**Use when:**
+- You want simple, predictable retry behavior
+- Server resources are limited
+- Order of attempts matters
+- You need traditional sequential retry logic
+
+```javascript
+const response = await fetchWithRetry('https://api.example.com/data', {
+  retries: 3,
+  timeout: 500,
+  growthFactor: 2
+})
 ```
+
+**How it works:**
+1. Attempt 1 with timeout=500ms
+2. If timeout or error, wait and retry with timeout=1000ms
+3. If timeout or error, wait and retry with timeout=2000ms
+4. Returns response or throws error after all retries exhausted
+
+### `fetchWithRacedRetries(url, options)`
+
+Concurrent retry strategy that launches new attempts when soft timeouts expire while keeping previous attempts alive. Returns the first successful response from any attempt.
+
+**Use when:**
+- You need the fastest possible response
+- Network latency is unpredictable
+- You can handle multiple concurrent requests
+- Earlier attempts might succeed even after their soft timeout expires
+
+```javascript
+const response = await fetchWithRacedRetries('https://api.example.com/data', {
+  retries: 3,
+  timeout: 500,
+  growthFactor: 2,
+  totalTimeout: 10000  // Hard limit for all attempts
+})
+```
+
+**How it works:**
+1. Attempt 0 starts with soft timeout=500ms and hard timeout=10000ms
+2. If soft timeout (500ms) expires before completion, Attempt 1 starts with soft timeout=1000ms
+3. Attempt 0 continues running in background (not aborted)
+4. Both attempts race - first successful response wins
+5. If Attempt 1's soft timeout expires, Attempt 2 starts with soft timeout=2000ms
+6. All three attempts race concurrently
+7. First successful response is returned, other attempts continue until hard timeout
+
+**Important:** Failed attempts are **not aborted** - they continue running until the hard timeout (`totalTimeout`) is reached. This allows slower attempts to potentially succeed and be returned.
+
+
+## Configuration
 
 You can set global options like this:
 
-```
+```javascript
+import { retryOptions } from '@dataforsyningen/retry/index.js'
 // Set the default retry timeout.
 retryOptions.timeout = 200
-// disable dynamically updating timeout.
-retryOptions.dynamicTimeout = false
+
+// Enable/disable dynamically updating timeout.
+retryOptions.dynamicTimeout = true
+
+// Set timeout boundaries
+retryOptions.minTimeout = 100
+retryOptions.maxTimeout = 5000
+
+// Configure how many signals needed before timeout adjustment
+retryOptions.timeoutSignalHeuristic = 2
 ```
 
-And you can use the retry with fetch like the usual fetch calls:
 
-```
-fetchWithRetry(resource, options)
-```
+## Options
 
-You can pass custom parameters in the options object in additional to fetch's usual options (see https://developer.mozilla.org/en-US/docs/Web/API/RequestInit).
+You can pass custom parameters in the options object in addition to fetch's usual options (see https://developer.mozilla.org/en-US/docs/Web/API/RequestInit).
 
-Here are the possible options:
+### Retry Options
+
 | Name | Default | Description |
 | -------- | ------- | ------- |
-| `retries` | 4 | The number of times the application should attempt to retry API calls. |
-| `timeout` | 500 | The time the application should wait before attempting a retry. |
+| `retries` | 4 | The maximum number of retry attempts. |
+| `timeout` | 500 | The initial timeout in milliseconds before attempting a retry (soft timeout for `fetchWithRacedRetries`). |
 | `growthFactor` | 2 | The exponential growth factor which the timeout is multiplied by after each failed attempt. |
-| `statusCodes` | [408, 500, 502, 503, 504, 506, 507, 508, 510] | The response status codes where a retry should be attempted. |
+| `statusCodes` | [408, 500, 502, 503, 504, 506, 507, 508, 510] | HTTP response status codes that should trigger a retry. |
+| `totalTimeout` | (calculated) | Hard timeout limit in milliseconds for all retry attempts combined (`fetchWithRacedRetries` only). Calculated as sum of exponential timeouts. |
 
+### Dynamic Timeout Options
+
+The library can automatically adjust the base timeout based on actual response times using a sliding window average:
+
+| Name | Default | Description |
+| -------- | ------- | ------- |
+| `dynamicTimeout` | true | Enable/disable adaptive timeout adjustment based on response times. |
+| `minTimeout` | 50 | Minimum allowed timeout in milliseconds. |
+| `maxTimeout` | 5000 | Maximum allowed timeout in milliseconds. |
+| `timeoutSignalHeuristic` | 2 | Number of consecutive slow/fast signals required before adjusting timeout. |
+
+**How dynamic timeout works:**
+- Maintains a sliding window of recent response times (default: last 10 measurements)
+- Outliers (>3x current timeout) are guarded and capped at the current timeout value
+- If average response time > 60% of current timeout → increment signal counter
+- If average response time < 30% of current timeout → decrement signal counter
+- When signal counter reaches ±`timeoutSignalHeuristic`, timeout is adjusted:
+  - **Increase:** `timeout = timeout * growthFactor` (capped at `maxTimeout`)
+  - **Decrease:** `timeout = timeout / growthFactor` (capped at `minTimeout`)
+- Signal counter is reset after each adjustment
+
+
+### Basic Usage with fetchWithRetry
+
+```javascript
+import { fetchWithRetry, retryOptions } from '@dataforsyningen/retry'
+
+// Configure global options
+retryOptions.timeout = 200
+retryOptions.dynamicTimeout = false
+
+// Make a request with retries
+try {
+  const response = await fetchWithRetry('https://api.example.com/data', {
+    retries: 3,
+    timeout: 500,
+    growthFactor: 2
+  })
+  const data = await response.json()
+  console.log(data)
+} catch (error) {
+  console.error('All retries failed:', error)
+}
+```
+
+### Using fetchWithRacedRetries for Faster Response
+
+```javascript
+import { fetchWithRacedRetries } from '@dataforsyningen/retry'
+
+// Race multiple concurrent attempts
+try {
+  const response = await fetchWithRacedRetries('https://api.example.com/data', {
+    retries: 5,
+    timeout: 300,
+    growthFactor: 2,
+    totalTimeout: 10000  // Hard timeout after 10 seconds
+  })
+  const data = await response.json()
+  console.log(data)
+} catch (error) {
+  console.error('All concurrent attempts failed:', error)
+}
+```
+
+### Implementation for tileloading
 Here is an example of how to use it with an OpenLayers WMTS source:
 
-```
+```javascript
 import WMTS from 'ol/source/WMTS'
 import TileState from 'ol/TileState.js'
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export { retryOptions, fetchWithTimeout, fetchWithRetry, retryWithPromises } from './src/retry'
+export { retryOptions, fetchWithTimeout, fetchWithRetry, fetchWithRacedRetries} from './src/retry'

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export { retryOptions, fetchWithTimeout, fetchWithRetry } from './src/retry'
+export { retryOptions, fetchWithTimeout, fetchWithRetry, retryWithPromises } from './src/retry'

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export { retryOptions, fetchWithTimeout, fetchWithRetry, fetchWithRacedRetries} from './src/retry'
+export { retryOptions, getTotalTime, fetchWithTimeout, fetchWithRetry, fetchWithRacedRetries} from './src/retry'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dataforsyningen/retry",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Klimadatastyrelsen's fetch retry library.",
   "main": "./public/index.html",
   "type": "module",

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,11 @@ export const RETRY_GROWTH_FACTOR = 2
 export const RETRY_STATUS_CODES = [408, 500, 502, 503, 504, 506, 507, 508, 510]
 // The base timeout should dynamically update based on the average response time.
 export const RETRY_DYNAMTIC_TIMEOUT = true
+
+export const getTotalTime = (timeout, growthfactor, retries) => {
+  let tempTimeout = timeout
+  for(let i = 1; i <= retries; i++ ){
+    tempTimeout += tempTimeout*growthfactor
+  }
+  return tempTimeout
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,13 @@ export const RETRY_STATUS_CODES = [408, 500, 502, 503, 504, 506, 507, 508, 510]
 // The base timeout should dynamically update based on the average response time.
 export const RETRY_DYNAMTIC_TIMEOUT = true
 
+// The maximum timeout allowed (set to Number.MAX_SAFE_INTEGER for compatability with previous version)
+export const RETRY_DYNAMIC_MAX_TIMEOUT = Number.MAX_SAFE_INTEGER
+// The minimum timeout allowed (set to 0 for compatability with previous version)
+export const RETRY_DYNAMIC_MIN_TIMEOUT = 0
+// The amount of consecutive times the average is above or below the threshhold required to trigger an expansion or contraction of the timeout
+export const RETRY_DYNAMIC_HEURISTIC = 3
+// A helperfunction to calculate the total timeout for fetchWithRacedRetries
 export const getTotalTime = (timeout, growthfactor, retries) => {
   let tempTimeout = timeout
   for(let i = 1; i <= retries; i++ ){

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,7 +10,7 @@ export const RETRY_STATUS_CODES = [408, 500, 502, 503, 504, 506, 507, 508, 510]
 export const RETRY_DYNAMTIC_TIMEOUT = true
 
 // The maximum timeout allowed (set to Number.MAX_SAFE_INTEGER for compatability with previous version)
-export const RETRY_DYNAMIC_MAX_TIMEOUT = Number.MAX_SAFE_INTEGER
+export const RETRY_DYNAMIC_MAX_TIMEOUT = 5000
 // The minimum timeout allowed (set to 0 for compatability with previous version)
 export const RETRY_DYNAMIC_MIN_TIMEOUT = 0
 // The amount of consecutive times the average is above or below the threshhold required to trigger an expansion or contraction of the timeout

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,6 +15,8 @@ export const RETRY_DYNAMIC_MAX_TIMEOUT = 5000
 export const RETRY_DYNAMIC_MIN_TIMEOUT = 0
 // The amount of consecutive times the average is above or below the threshhold required to trigger an expansion or contraction of the timeout
 export const RETRY_DYNAMIC_HEURISTIC = 3
+// Window Size for sliding average
+export const WINDOW_SIZE  = 10
 // A helperfunction to calculate the total timeout for fetchWithRacedRetries
 export const getTotalTime = (timeout, growthfactor, retries) => {
   let tempTimeout = timeout

--- a/src/retry.js
+++ b/src/retry.js
@@ -183,7 +183,7 @@ const retryPromiseAttempt = async (attemptNumber, activeAttempts, url, options, 
   } else {
     activeAttempts.push(attemptResult.promise)
     
-    return retryPromiseAttempt(attemptNumber + 1, activeAttempts, url, options, totalTimeout - optionsClone.timeout)
+    return retryPromiseAttempt(attemptNumber + 1, activeAttempts, url, optionsClone, totalTimeout - optionsClone.timeout)
   }
 }
 

--- a/src/retry.js
+++ b/src/retry.js
@@ -47,7 +47,6 @@ function updateBaseTimeout(responseTime) {
  */
 async function fetchWithTimeout(url, options = {}) {
   const { timeout = retryOptions.timeout } = options
-  console.log('timeout', timeout)
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeout)
   const response = await fetch(url, {
@@ -165,7 +164,6 @@ const preserveFetchPromise = (url, options, activeAttempts, attemptNumber, remai
  * @throws {AggregateError} When all attempts fail or exceed total timeout
  */
 const retryPromiseAttempt = async (attemptNumber, activeAttempts, url, options, totalTimeout) => {
-  console.log(attemptNumber)
   // Base case: all retries exhausted, wait for any active fetch to complete
   if (attemptNumber > retryOptions.retries) {
     return Promise.any(activeAttempts)

--- a/src/retry.js
+++ b/src/retry.js
@@ -7,6 +7,7 @@ import {
   RETRY_DYNAMIC_MIN_TIMEOUT,
   RETRY_DYNAMIC_MAX_TIMEOUT,
   RETRY_DYNAMIC_HEURISTIC,
+  WINDOW_SIZE,
   getTotalTime,
 } from './constants.js'
 
@@ -22,7 +23,7 @@ const retryOptions = {
   totalTimeout: getTotalTime(RETRY_TIMEOUT, RETRY_GROWTH_FACTOR, RETRY_ATTEMPTS)
 }
 
-const WINDOW_SIZE  = 10
+
 let responseTimeWindow = []
 let timeoutSignalCount = 0
 

--- a/src/retry.js
+++ b/src/retry.js
@@ -69,7 +69,7 @@ const updateBaseTimeout = (responseTime) => {
  * Fetch with a max timeout.
  * @param {*} url - The endpoint URL for the HTTP GET request.
  * @param {*} options - Options (timeout) and https://developer.mozilla.org/en-US/docs/Web/API/RequestInit
- * @returns 
+ * @returns {}
  */
 async function fetchWithTimeout(url, options = {}) {
   const { timeout = retryOptions.timeout } = options
@@ -118,62 +118,92 @@ async function fetchWithRetry (url, options = {}) {
 }
 
 /**
- * Races a fetch attempt against a timeout while preserving the fetch promise.
- * Used by retryPromiseAttempt to implement concurrent retry attempts.
+ * Races a fetch attempt against a soft timeout while preserving the fetch promise for future races.
+ * Used by retryPromiseAttempt to implement concurrent retry attempts with exponential backoff.
  * 
- * Races three promises:
- * 1. fetchWithTimeout with hard timeout (remainingTime)
- * 2. Soft timeout that triggers next retry (options.timeout)
- * 3. All previously active fetch attempts
+ * This function manages three racing conditions:
+ * 1. The actual fetch request with a hard timeout (remainingTime) enforced by fetchWithTimeout
+ * 2. A soft timeout (options.timeout) that triggers the next retry attempt while keeping this fetch alive
+ * 3. All previous valid fetch attempts (attemptArray) that are still running
  * 
- * @param {string} url - The endpoint URL
- * @param {Object} options - Fetch options (timeout, statusCodes, etc.)
- * @param {Array<Promise>} activeAttempts - Promises from previous attempts still running
- * @param {number} attemptNumber - Current attempt number (0-indexed)
- * @param {number} remainingTime - Hard timeout limit for fetchWithTimeout
- * @returns {Promise<Object>} Resolves with:
- *   - {success: true, promise, attemptNumber, response} if fetch completes before soft timeout
- *   - {success: false, promise} if soft timeout expires (fetch continues in background)
- *   - Previous attempt's result if it completes first
+ * 
+ * @param {string} url - The endpoint URL for the HTTP request
+ * @param {Object} options - Fetch options including:
+ *   @param {number} [options.timeout] - Soft timeout in ms that triggers next retry (default: retryOptions.timeout)
+ *   @param {number[]} [options.statusCodes] - HTTP status codes that should trigger retry (default: retryOptions.statusCodes)
+ *   @param {RequestInit} [options.*] - Any additional fetch API options (headers, method, body, etc.)
+ * @param {Object} preserveOptions - Configuration for promise preservation:
+ *   @param {Promise<Object>[]} preserveOptions.attemptArray - Array of wrapper promises from previous timed-out attempts still running
+ *   @param {number} preserveOptions.attemptNumber - Current attempt number (0-indexed)
+ *   @param {number} preserveOptions.remainingTime - Hard timeout limit in ms for the total operation
+ * 
+ * @returns {Promise<Object>} Always resolves (never rejects) with one of:
+ *   - **Success (valid response)**: `{success: true, promise: fetchPromiseWrapper, attemptNumber, response: Response}`
+ *   - **Success (hard timeout reached)**: `{success: true, promise: fetchPromiseWrapper, attemptNumber, response: AbortError}`
+ *   - **Retry (soft timeout)**: `{success: false, promise: fetchPromiseWrapper, attemptNumber}`
+ *   - **Retry (retriable error)**: `{success: false, attemptNumber}`
  */
-const preserveFetchPromise = (url, options, activeAttempts, attemptNumber, remainingTime) => {
+const preserveFetchPromise = (url, options, preserveOptions) => {
+  // Extract from options
   const {
     timeout = retryOptions.timeout,
     statusCodes = retryOptions.statusCodes
   } = options
 
+  // Extract from preserveOptions
+  const {
+    attemptArray,
+    attemptNumber,
+    remainingTime
+  } = preserveOptions
+
   const startTime = Date.now()
   const clonedOptions = structuredClone(options)
   clonedOptions.timeout = remainingTime
-  const fetchPromise = new Promise(async (resolve, reject) => {
+
+  // Create the fetch promise that will resolve/reject based on response
+  const fetchPromise = (async () => {
     try {
       const response = await fetchWithTimeout(url, clonedOptions)
-
-      const responseTime = Date.now() - startTime
-      updateBaseTimeout(responseTime)
-
+      updateBaseTimeout(Date.now() - startTime)
+      
       if (statusCodes.includes(response.status)) {
-        reject(new Error(`Bad Response`))
-      } else {
-        resolve(response)
+        throw new Error("[Retry] Invalid response code")
       }
+      return response
     } catch (error) {
       updateBaseTimeout(Date.now() - startTime)
-      reject(error)
+      throw error
     }
-  }).then(response => {
-    return ({ success: true, promise: fetchPromise, attemptNumber: attemptNumber, response })
-  })
-  const attemptarr = [fetchPromise,
-    new Promise(resolve => {
-      setTimeout(() => {
-        resolve({ success: false, promise: fetchPromise, attemptNumber: attemptNumber })
-      }, timeout)
-    }),
-    ...activeAttempts]
+  })()
 
+  // Wrap fetchPromise to always resolve and distinguish error types
+  const fetchPromiseWrapper = fetchPromise.then(
+    (response) => ({ success: true, promise: fetchPromiseWrapper, attemptNumber, response }),
+    (error) => {
+      // If it's a hard timeout (AbortError), we should stop retrying completely
+      if (error.name === 'AbortError') {
+        return { success: true, promise: fetchPromiseWrapper, attemptNumber, response: error }
+      }
+      // Otherwise it's a retriable error (network error, invalid status code, etc.)
+      // Don't include promise in race - we won't wait for this attempt
+      return { success: false, attemptNumber }
+    }
+  )
+
+  // Soft timeout promise that resolves after timeout period
+  const softTimeout = new Promise(resolve => {
+    setTimeout(() => {
+      // Include the wrapper promise so we can still race it in future attempts
+      resolve({ success: false, promise: fetchPromiseWrapper, attemptNumber })
+    }, timeout)
+  })
+
+  // Race the wrapped fetch against soft timeout and all previous attempts
   return Promise.race([
-    ...attemptarr
+    softTimeout,
+    fetchPromiseWrapper,
+    ...attemptArray
   ])
 }
 
@@ -182,35 +212,65 @@ const preserveFetchPromise = (url, options, activeAttempts, attemptNumber, remai
  * Recursively attempts fetch with exponentially increasing timeouts.
  * Launches new attempts when soft timeouts expire while keeping previous attempts alive.
  * 
- * @param {number} attemptNumber - Current attempt number (0-indexed)
- * @param {Array<Promise>} activeAttempts - Array of fetch promises from timed-out attempts still running
- * @param {string} url - The endpoint URL
- * @param {Object} options - Fetch options (timeout, statusCodes, etc.)
+ * @param {string} url - Endpoint to fetch
+ * @param {Object} options - Fetch options including:
+ *   @param {number} [options.timeout] - Soft timeout in ms that triggers next retry (default: retryOptions.timeout)
+ *   @param {number[]} [options.statusCodes] - HTTP status codes that should trigger retry (default: retryOptions.statusCodes)
+ *   @param {RequestInit} [options.*] - Any additional fetch API options (headers, method, body, etc.)
+ * @param {Object} preserveOptions - Configuration for promise preservation:
+ *   @param {Promise<Object>[]} preserveOptions.attemptArray - Array of wrapper promises from previous timed-out attempts still running
+ *   @param {number} preserveOptions.attemptNumber - Current attempt number (0-indexed)
+ *   @param {number} preserveOptions.remainingTime - Hard timeout limit in ms for the total operation
  * @returns {Promise<Response>} Resolves with first successful response from any attempt
  * @throws {AggregateError} When all attempts fail or exceed total timeout
  */
-const retryPromiseAttempt = async (attemptNumber, activeAttempts, url, options, totalTimeout) => {
-  // Base case: all retries exhausted, wait for any active fetch to complete
-  if (attemptNumber > retryOptions.retries) {
-    return Promise.any(activeAttempts)
+const retryPromiseAttempt = async (url, options, preserveOptions) => {
+  const {
+    retries = retryOptions.retries,
+    timeout = retryOptions.timeout,
+    growthFactor = retryOptions.growthFactor,
+  } = options
+
+  const {
+    attemptArray,
+    attemptNumber,
+    remainingTime
+  } = preserveOptions
+
+  // Base case: all retries exhausted, return first thing that resolves/rejects.
+  if (attemptNumber > retries) {
+    return Promise.any(attemptArray).then(result => {
+      if(result.success) {
+        return result.response
+      }
+      throw new AggregateError([], 'All attempt exhausted')
+    })
   }
 
   // Clone and increase timeout exponentially for this attempt
   const optionsClone = structuredClone(options)
   if(attemptNumber > 0) {
-    optionsClone.timeout = options.timeout * retryOptions.growthFactor
+    optionsClone.timeout = timeout * growthFactor
   }
 
-  const attemptResult = await preserveFetchPromise(url, optionsClone, activeAttempts, attemptNumber, totalTimeout)
+
+  const attemptResult = await preserveFetchPromise(url, optionsClone, preserveOptions)
+
 
   if (attemptResult.success) {
     //console.log(`Fetch Promise ${attemptResult.attemptNumber} out of ${attemptNumber}`)
     return attemptResult.response
-  } else {
-    activeAttempts.push(attemptResult.promise)
-    
-    return retryPromiseAttempt(attemptNumber + 1, activeAttempts, url, optionsClone, totalTimeout - optionsClone.timeout)
   }
+
+  const attemptArrayUpdate = attemptResult?.promise ? [...attemptArray, attemptResult.promise]: attemptArray
+
+  return retryPromiseAttempt(url, optionsClone, 
+    {
+      attemptArray: attemptArrayUpdate,
+      attemptNumber: attemptNumber + 1,
+      remainingTime: remainingTime - optionsClone.timeout
+    }
+  )
 }
 
 /**
@@ -231,8 +291,14 @@ const fetchWithRacedRetries = async (url, options = {}) => {
     totalTimeout = retryOptions.totalTimeout
   } = options
   
+  const initialState = {
+    attemptArray: [],
+    attemptNumber: 0,
+    remainingTime: totalTimeout
+  }
+
   try {
-    return await retryPromiseAttempt(0, [], url, { ...options, timeout, statusCodes, growthFactor}, totalTimeout)
+    return await retryPromiseAttempt(url, { ...options, timeout, statusCodes, growthFactor}, initialState)
   } catch (error) {
     throw new Error(`All retries failed. Url: ${url}, msg: ${error.message}`)
   }
@@ -240,6 +306,7 @@ const fetchWithRacedRetries = async (url, options = {}) => {
 
 export {
   retryOptions,
+  getTotalTime,
   fetchWithTimeout,
   fetchWithRetry,
   preserveFetchPromise,

--- a/src/retry.js
+++ b/src/retry.js
@@ -4,10 +4,10 @@ import {
   RETRY_GROWTH_FACTOR,
   RETRY_STATUS_CODES,
   RETRY_DYNAMTIC_TIMEOUT,
-  getTotalTime,
   RETRY_DYNAMIC_MIN_TIMEOUT,
   RETRY_DYNAMIC_MAX_TIMEOUT,
-  RETRY_DYNAMIC_HEURISTIC
+  RETRY_DYNAMIC_HEURISTIC,
+  getTotalTime,
 } from './constants.js'
 
 const retryOptions = {
@@ -22,12 +22,17 @@ const retryOptions = {
   totalTimeout: getTotalTime(RETRY_TIMEOUT, RETRY_GROWTH_FACTOR, RETRY_ATTEMPTS)
 }
 
-let fetchCount = 0
-let fetchResponseTimeSum = 0
+const WINDOW_SIZE  = 10
+let responseTimeWindow = []
 let timeoutSignalCount = 0
 
 const getAverageResponseTime = () => {
-  return fetchResponseTimeSum / fetchCount
+  if (responseTimeWindow.length === 0) return 0
+  const sum = responseTimeWindow.reduce((acc, val) => acc + val, 0)
+  return sum / responseTimeWindow.length
+}
+const resetTimeoutCalc = () => {
+  responseTimeWindow = []
 }
 
 const extendTimeout = () => {
@@ -37,28 +42,40 @@ const extendTimeout = () => {
 }
 
 const contractTimeout = () => {
-  const newTimeout = retryOptions.timeout * (1 / retryOptions.growthFactor)
-  retryOptions.timeout *= newTimeout < retryOptions.minTimeout ? retryOptions.minTimeout : newTimeout 
+  const contractFactor = (1/retryOptions.growthFactor)
+  const newTimeout = retryOptions.timeout * contractFactor
+  retryOptions.timeout = newTimeout < retryOptions.minTimeout ? retryOptions.minTimeout : newTimeout 
   retryOptions.totalTime = getTotalTime(retryOptions.timeout, retryOptions.growthFactor, retryOptions.retries)
 }
 
 
 const updateBaseTimeout = (responseTime) => {
+
   if (!retryOptions.dynamicTimeout) return
-  fetchCount += 1
-  //Guard against against outliers that do not reflect average response time (i.e move stably up or down untill equilibrium is reached)
-  fetchResponseTimeSum += responseTime > retryOptions.timeout*3 ? retryOptions.timeout : responseTime 
-  // Increase max timeout when average response time is more than 3/5 of the max.
+  
+  // Guard against outliers
+  const guardedResponseTime = responseTime > retryOptions.timeout * 3 
+    ? retryOptions.timeout 
+    : responseTime
+  
+  // Add new measurement
+  responseTimeWindow.push(guardedResponseTime)
+  
+  // Remove oldest if window is full
+  if (responseTimeWindow.length > WINDOW_SIZE) {
+    responseTimeWindow.shift()
+  }
+  
+  
   if (getAverageResponseTime() > retryOptions.timeout * 0.6) {
     timeoutSignalCount++
-    if(timeoutSignalCount >= retryOptions.timeoutSignalHeuristic) {
+    if (timeoutSignalCount >= retryOptions.timeoutSignalHeuristic) {
       extendTimeout()
       timeoutSignalCount = 0    
     }
-  // Reduce max timeout when the average response time is less than 1/4 of the max.
-  } else if (getAverageResponseTime() < retryOptions.timeout * 0.25) {
+  } else if (getAverageResponseTime() < retryOptions.timeout * 0.3) {
     timeoutSignalCount--
-    if(timeoutSignalCount <= retryOptions.timeoutSignalHeuristic) {
+    if (timeoutSignalCount <= -retryOptions.timeoutSignalHeuristic) {
       contractTimeout()
       timeoutSignalCount = 0    
     }
@@ -157,9 +174,10 @@ const preserveFetchPromise = (url, options, preserveOptions) => {
     remainingTime
   } = preserveOptions
 
-  const startTime = Date.now()
+
   const clonedOptions = structuredClone(options)
   clonedOptions.timeout = remainingTime
+  const startTime = Date.now()
 
   // Create the fetch promise that will resolve/reject based on response
   const fetchPromise = (async () => {
@@ -258,7 +276,7 @@ const retryPromiseAttempt = async (url, options, preserveOptions) => {
 
 
   if (attemptResult.success) {
-    //console.log(`Fetch Promise ${attemptResult.attemptNumber} out of ${attemptNumber}`)
+    //console.log(`Fetch Promise ${attemptResult.attemptNumber} out of ${attemptNumber}`, attemptResult)
     return attemptResult.response
   }
 
@@ -306,6 +324,7 @@ const fetchWithRacedRetries = async (url, options = {}) => {
 
 export {
   retryOptions,
+  resetTimeoutCalc,
   getTotalTime,
   fetchWithTimeout,
   fetchWithRetry,

--- a/test/integration/dynamicTimeout.test.js
+++ b/test/integration/dynamicTimeout.test.js
@@ -1,7 +1,7 @@
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it, beforeEach, mock } from 'node:test'
 import assert from 'node:assert'
 import nock from 'nock'
-import { retryOptions, fetchWithRetry } from '../../src/retry.js'
+import { retryOptions, getTotalTime, fetchWithRetry, fetchWithRacedRetries, resetTimeoutCalc } from '../../src/retry.js'
 
 const url = 'http://example.com'
 
@@ -17,7 +17,9 @@ describe('dynamic timeout tests', async () => {
   beforeEach(() => nock.cleanAll())
 
   it('Check that the dynamic timeout correctly increases the base timeout duration', async () => {
+    resetTimeoutCalc()
     retryOptions.timeout = 50
+    retryOptions.timeoutSignalHeuristic = 1
     mockCall(1000, 100)
     try {
       const response = await fetchWithRetry(url,
@@ -26,15 +28,17 @@ describe('dynamic timeout tests', async () => {
           growthFactor: 2
         }
       )
-      // 50 -> 100 -> 200 -> 400 -> 800 -> 1600
-      assert.equal(retryOptions.timeout, 1600)
+      // 50 -> 100 -> 200 -> 400 -> 800 //attempt 2 succeeds
+      assert.equal(retryOptions.timeout, 800)
     } catch (error) {
       assert.fail(error.message)
     }
   })
 
   it('Check that the dynamic timeout correctly reduces the base timeout duration', async () => {
+    resetTimeoutCalc()
     retryOptions.timeout = 1600
+    retryOptions.timeoutSignalHeuristic = 1
     try {
       mockCall(50, 50)
       for(let i = 0; i < 50; i++) {
@@ -45,15 +49,17 @@ describe('dynamic timeout tests', async () => {
           }
         )
       }
-      // 1600 -> 1200 -> 900 -> 675 -> 506.25 -> 379.6875 -> 284.765625
-      assert.equal(retryOptions.timeout, 284.765625)
+      // 1600 -> 800 -> 400 -> 200-> 100
+      assert.equal(retryOptions.timeout, 100)
     } catch (error) {
       assert.fail(error.message)
     }
   })
 
   it('Check that the dynamic timeout correctly increases and reduces the base timeout duration', async () => {
+    resetTimeoutCalc()
     retryOptions.timeout = 50
+    retryOptions.timeoutSignalHeuristic = 1
     mockCall(2000, 50)
     try {
       const response = await fetchWithRetry(url,
@@ -62,10 +68,10 @@ describe('dynamic timeout tests', async () => {
           growthFactor: 2
         }
       )
-      // 50 -> 100 -> 200 -> 400
-      assert.equal(retryOptions.timeout, 400)
+      // 50 -> 100 -> 200 -> 400 -> 800 -> 1600
+      assert.equal(retryOptions.timeout, 1600)
       nock.cleanAll()
-      mockCall(0, 50)
+      mockCall(50, 50)
       for(let i = 0; i < 50; i++) {
         const response = await fetchWithRetry(url,
           {
@@ -74,10 +80,141 @@ describe('dynamic timeout tests', async () => {
           }
         )
       }
-      // 400 -> 300
-      assert.equal(retryOptions.timeout, 300)
+      // 1600 -> 800 -> 400 -> 200 -> 100
+      assert.equal(retryOptions.timeout, 100)
     } catch (error) {
       assert.fail(error.message)
     }
   })
+
+  it('check that dynamic timeout increases correctly for retryWithRacedPromises', async () => {
+    resetTimeoutCalc()
+    retryOptions.timeout = 50
+    retryOptions.maxTimeout = getTotalTime()
+    retryOptions.timeoutSignalHeuristic = 1
+    
+    mockCall(400, 15)
+    for(let i = 0; i < 5; i++) {
+      const response1 = await fetchWithRacedRetries(url, {
+        retries: 2,  //50 * 2^2 = 200  when timining out 
+        growthFactor: 2
+      })
+    }
+    assert.equal(retryOptions.timeout, 800)
+
+    nock.cleanAll()
+    mockCall(25, 10)
+    for(let i = 0; i < 10; i++) {
+      const response2 = await fetchWithRacedRetries(url, {
+        retries: 2,
+        growthFactor: 2
+      })
+    }
+    // 100 -> 50
+    assert.equal(retryOptions.timeout, 100)
+  })
+
+
+  it('Check that dynamic timeout respects minTimeout boundary', async () => {
+    resetTimeoutCalc()
+    retryOptions.timeout = 200
+    retryOptions.minTimeout = 100
+    retryOptions.timeoutSignalHeuristic = 1
+    
+    mockCall(10, 50)
+    for(let i = 0; i < 50; i++) {
+      const response = await fetchWithRetry(url, {
+        retries: 1,
+        growthFactor: 2
+      })
+    }
+    // Should decrease but stop at minTimeout
+    // 200 -> 100 (stops here)
+    assert.equal(retryOptions.timeout, 100)
+  })
+
+  it('Check that dynamic timeout respects maxTimeout boundary', async () => {
+    resetTimeoutCalc()
+    retryOptions.timeout = 100
+    retryOptions.maxTimeout = 400
+    retryOptions.timeoutSignalHeuristic = 1
+    
+    mockCall(5000, 100)
+    try {
+      const response = await fetchWithRetry(url, {
+        retries: 100,
+        growthFactor: 2
+      })
+      // Should increase but stop at maxTimeout
+      // 100 -> 200 -> 400 (stops here)
+      assert.equal(retryOptions.timeout, 400)
+    } catch (error) {
+      assert.fail(error.message)
+    }
+  })
+  it('Check that timeoutSignalHeuristic requires multiple signals to change', async () => {
+    resetTimeoutCalc()
+    retryOptions.timeout = 100
+    retryOptions.timeoutSignalHeuristic = 3  // Require 3 signals
+    
+    mockCall(1000, 100)
+    try {
+      const response = await fetchWithRetry(url, {
+        retries: 100,
+        growthFactor: 2
+      })
+      // Need 3 consecutive signals to increase
+      // First 3 timeouts trigger first increase: 100 -> 200
+      assert(retryOptions.timeout >= 200, 'Timeout should have increased')
+    } catch (error) {
+      assert.fail(error.message)
+    }
+  })
+  it('Check that fetchWithRacedRetries adapts timeout with concurrent attempts', async () => {
+    resetTimeoutCalc()
+    retryOptions.timeout = 50
+    retryOptions.maxTimeout = getTotalTime()
+    retryOptions.timeoutSignalHeuristic = 1
+    
+    // Slow responses that will cause multiple concurrent attempts
+    mockCall(500, 20)
+    for(let i = 0; i < 5; i++) {
+      const response = await fetchWithRacedRetries(url, {
+        retries: 3,
+        growthFactor: 2
+      })
+    }
+    
+    // Should increase timeout due to consistent slow responses
+    assert(retryOptions.timeout >= 200, 
+      `Timeout ${retryOptions.timeout} should have increased`)
+  })
+  it('Check that extreme outliers are guarded and do not skew average', async () => {
+    resetTimeoutCalc()
+    retryOptions.timeout = 100
+    retryOptions.timeoutSignalHeuristic = 1
+    
+    // Mix of normal and extreme responses
+    mockCall(80, 5)
+    for(let i = 0; i < 5; i++) {
+      await fetchWithRetry(url, { retries: 1, growthFactor: 2 })
+    }
+    
+    const timeoutBefore = retryOptions.timeout
+    
+    nock.cleanAll()
+    // Extreme outlier (should be guarded to timeout * 3)
+    mockCall(10000, 1)
+    try {
+      await fetchWithRetry(url, { retries: 3, growthFactor: 2 })
+      assert.fail("error should be thrown with extreme outliers")
+    } catch (error) {
+    }
+    
+    // Timeout shouldn't jump dramatically due to outlier guarding
+    assert(retryOptions.timeout <= timeoutBefore * 4,
+      'Outlier should be guarded and not cause extreme timeout increase')
+  })
+
 })
+

--- a/test/integration/preserveFetchPromise.test.js
+++ b/test/integration/preserveFetchPromise.test.js
@@ -1,0 +1,124 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert'
+import nock from 'nock'
+import { preserveFetchPromise } from '../../src/retry.js'
+
+const url = 'http://example.com'
+
+const mockCall = (delay = 0, responseCode = 200, count = 1) => {
+  return nock(url)
+    .get('/')
+    .delay(delay)
+    .times(count)
+    .reply(responseCode, {})
+}
+
+
+describe('preserveFetchTests', async () => {
+  beforeEach(() => nock.cleanAll())
+  it('Check that the attempt returns unresolved promise', async () => {
+    const scope = nock(url)
+      .get('/')
+      .delay(100)
+      .reply(200, {})
+    try {
+      const response = await preserveFetchPromise(
+        url,
+        { timeout: 50 }, [], 0, 200
+      )
+      assert(response.success === false && !response?.response)
+    } catch (error) {
+      assert.fail(`Error was thrown: ${error.message}`)
+    }
+  })
+  it('Check that the attempt returns resolved promise', async () => {
+    const scope = nock(url)
+      .get('/')
+      .delay(100)
+      .reply(200, {})
+    try {
+      const response = await preserveFetchPromise(
+        url,
+        { timeout: 200 }, [], 0, 200
+      )
+      assert(response.success === true && response.response.status === 200)
+    } catch (error) {
+      assert.fail(`Error was thrown: ${error.message}`)
+    }
+  }),
+  it('race multiple attempts and retrieve the first one to resolve', async () => {
+    mockCall(250, 200)
+    mockCall(100, 305)
+    try {
+      const weakTimedOutResponse = await preserveFetchPromise(
+        url,
+        { timeout: 200 },
+        [],
+        0,
+        400
+      )
+
+      assert(weakTimedOutResponse.success === false && !weakTimedOutResponse?.response)
+      const resolvedResponse = await (preserveFetchPromise(
+        url,
+        { timeout: 200 },
+        [weakTimedOutResponse.promise],
+        1,
+        200
+      ))
+      assert(resolvedResponse.success === true && resolvedResponse.response.status === 200)
+    } catch (error) {
+      assert.fail(`Error was thrown: ${error.message}`)
+    }
+  }),
+  it('preserveFetchPromise should be aborted at bad response error', async () => {
+    mockCall(150, 500)
+    mockCall(100, 200)
+    try {
+      const weakTimedOutResponse = await preserveFetchPromise(
+        url,
+        { timeout: 200 },
+        [],
+        0,
+        400
+      )
+      console.log(weakTimedOutResponse)
+      assert(weakTimedOutResponse.success === false && !weakTimedOutResponse?.response)
+      const throwingResponse = await (preserveFetchPromise(
+        url,
+        { timeout: 200 },
+        [weakTimedOutResponse.promise],
+        1,
+        200
+      ))
+      assert.fail('Error was not thrown')
+    } catch (error) {
+      console.log(error)
+      assert.equal(error.message, 'Bad Response')
+    }
+  }),
+  it('When one strong timeout is hit, we should trigger an error', async () => {
+    mockCall(250, 305)
+    mockCall(100, 200)
+    try {
+      const weakTimedOutResponse = await preserveFetchPromise(
+        url,
+        { timeout: 150 },
+        [],
+        0,
+        200
+      )
+      assert(weakTimedOutResponse.success === false && !weakTimedOutResponse?.response)
+      const throwingResponse = await (preserveFetchPromise(
+        url,
+        { timeout: 200 },
+        [weakTimedOutResponse.promise],
+        1,
+        200
+      ))
+      assert.fail('Error was not thrown')
+    } catch (error) {
+      assert.equal(error.message, 'This operation was aborted')
+    }
+  })
+})

--- a/test/integration/preserveFetchPromise.test.js
+++ b/test/integration/preserveFetchPromise.test.js
@@ -82,7 +82,6 @@ describe('preserveFetchTests', async () => {
         0,
         400
       )
-      console.log(weakTimedOutResponse)
       assert(weakTimedOutResponse.success === false && !weakTimedOutResponse?.response)
       const throwingResponse = await (preserveFetchPromise(
         url,
@@ -93,7 +92,6 @@ describe('preserveFetchTests', async () => {
       ))
       assert.fail('Error was not thrown')
     } catch (error) {
-      console.log(error)
       assert.equal(error.message, 'Bad Response')
     }
   }),

--- a/test/integration/preserveFetchPromise.test.js
+++ b/test/integration/preserveFetchPromise.test.js
@@ -13,110 +13,140 @@ const mockCall = (delay = 0, responseCode = 200, count = 1) => {
     .reply(responseCode, {})
 }
 
-
 describe('preserveFetchTests', async () => {
   beforeEach(() => nock.cleanAll())
-  it('Check that the attempt returns unresolved promise', async () => {
-    const scope = nock(url)
-      .get('/')
-      .delay(100)
-      .reply(200, {})
+  
+  it('Check that the attempt returns unresolved promise when soft timeout expires', async () => {
+    mockCall(100, 200)
     try {
       const response = await preserveFetchPromise(
         url,
-        { timeout: 50 }, [], 0, 200
+        { timeout: 50 },
+        { attemptArray: [], attemptNumber: 0, remainingTime: 400 }
       )
-      assert(response.success === false && !response?.response)
+      // Soft timeout (50ms) expires before fetch completes (100ms)
+      assert.equal(response.success, false, 'Should be unsuccessful due to soft timeout')
+      assert.ok(response.promise, 'Should include promise for future racing')
+      assert.equal(response.attemptNumber, 0, 'Should have correct attempt number')
+      assert.equal(response.response, undefined, 'Should not have response yet')
     } catch (error) {
       assert.fail(`Error was thrown: ${error.message}`)
     }
   })
-  it('Check that the attempt returns resolved promise', async () => {
-    const scope = nock(url)
-      .get('/')
-      .delay(100)
-      .reply(200, {})
+  
+  it('Check that the attempt returns resolved promise when fetch completes before timeout', async () => {
+    mockCall(100, 200)
     try {
       const response = await preserveFetchPromise(
         url,
-        { timeout: 200 }, [], 0, 200
+        { timeout: 200 },
+        { attemptArray: [], attemptNumber: 0, remainingTime: 400 }
       )
-      assert(response.success === true && response.response.status === 200)
+      // Fetch completes (100ms) before soft timeout (200ms)
+      assert.equal(response.success, true, 'Should be successful')
+      assert.equal(response.response.status, 200, 'Should have correct status')
+      assert.equal(response.attemptNumber, 0, 'Should have correct attempt number')
+      assert.ok(response.promise, 'Should include promise wrapper')
     } catch (error) {
       assert.fail(`Error was thrown: ${error.message}`)
     }
-  }),
-  it('race multiple attempts and retrieve the first one to resolve', async () => {
+  })
+  
+  it('Race multiple attempts and retrieve the first one to resolve', async () => {
     mockCall(250, 200)
-    mockCall(100, 305)
+    mockCall(100, 200)
     try {
+      // First attempt: soft timeout at 200ms, fetch takes 250ms
       const weakTimedOutResponse = await preserveFetchPromise(
         url,
         { timeout: 200 },
-        [],
-        0,
-        400
+        { attemptArray: [], attemptNumber: 0, remainingTime: 400 }
       )
 
-      assert(weakTimedOutResponse.success === false && !weakTimedOutResponse?.response)
-      const resolvedResponse = await (preserveFetchPromise(
+      assert.equal(weakTimedOutResponse.success, false, 'First attempt should timeout')
+      assert.ok(weakTimedOutResponse.promise, 'Should preserve promise')
+      assert.equal(weakTimedOutResponse.attemptNumber, 0)
+
+      // Second attempt: races against first attempt's preserved promise
+      const resolvedResponse = await preserveFetchPromise(
         url,
         { timeout: 200 },
-        [weakTimedOutResponse.promise],
-        1,
-        200
-      ))
-      assert(resolvedResponse.success === true && resolvedResponse.response.status === 200)
+        { attemptArray: [weakTimedOutResponse.promise], attemptNumber: 1, remainingTime: 200 }
+      )
+      
+      // Second attempt completes faster (100ms) and wins the race
+      assert.equal(resolvedResponse.success, true, 'Second attempt should succeed')
+      assert.equal(resolvedResponse.response.status, 200, 'Should have correct status')
     } catch (error) {
       assert.fail(`Error was thrown: ${error.message}`)
     }
-  }),
-  it('preserveFetchPromise should be aborted at bad response error', async () => {
-    mockCall(150, 500)
-    mockCall(100, 200)
+  })
+  
+  it('preserveFetchPromise should fail on bad response status code', async () => {
+    mockCall(50, 500)
     try {
-      const weakTimedOutResponse = await preserveFetchPromise(
+      const response = await preserveFetchPromise(
         url,
-        { timeout: 200 },
-        [],
-        0,
-        400
+        { timeout: 200, statusCodes: [500, 502, 503, 504] },
+        { attemptArray: [], attemptNumber: 0, remainingTime: 400 }
       )
-      assert(weakTimedOutResponse.success === false && !weakTimedOutResponse?.response)
-      const throwingResponse = await (preserveFetchPromise(
-        url,
-        { timeout: 200 },
-        [weakTimedOutResponse.promise],
-        1,
-        200
-      ))
-      assert.fail('Error was not thrown')
+      
+      // Fetch completes quickly but with bad status code
+      assert.equal(response.success, false, 'Should fail due to bad status code')
+      assert.equal(response.attemptNumber, 0)
+      assert.equal(response.promise, undefined, 'Should not preserve promise for non-retriable error')
     } catch (error) {
-      assert.equal(error.message, 'Bad Response')
+      assert.fail(`Unexpected error was thrown: ${error.message}`)
     }
-  }),
-  it('When one strong timeout is hit, we should trigger an error', async () => {
-    mockCall(250, 305)
-    mockCall(100, 200)
+  })
+  
+  it('When hard timeout is hit, should return AbortError as successful response', async () => {
+    mockCall(500, 200)
     try {
-      const weakTimedOutResponse = await preserveFetchPromise(
-        url,
-        { timeout: 150 },
-        [],
-        0,
-        200
-      )
-      assert(weakTimedOutResponse.success === false && !weakTimedOutResponse?.response)
-      const throwingResponse = await (preserveFetchPromise(
+      const response = await preserveFetchPromise(
         url,
         { timeout: 200 },
-        [weakTimedOutResponse.promise],
-        1,
-        200
-      ))
-      assert.fail('Error was not thrown')
+        { attemptArray: [], attemptNumber: 0, remainingTime: 100 }
+      )
+      
+      // Hard timeout (100ms) is hit before fetch completes (500ms)
+      assert.equal(response.success, true, 'Should be "successful" to stop retrying')
+      assert.equal(response.response.name, 'AbortError', 'Should contain AbortError')
+      assert.equal(response.attemptNumber, 0)
+      assert.ok(response.promise, 'Should include promise wrapper')
     } catch (error) {
-      assert.equal(error.message, 'This operation was aborted')
+      assert.fail(`Unexpected error was thrown: ${error.message}`)
+    }
+  })
+  
+  it('Earlier attempt wins race even after soft timeout', async () => {
+    mockCall(150, 200)
+    mockCall(200, 200)
+    try {
+      // First attempt: soft timeout at 100ms, but fetch completes at 150ms
+      const firstAttempt = await preserveFetchPromise(
+        url,
+        { timeout: 100 },
+        { attemptArray: [], attemptNumber: 0, remainingTime: 500 }
+      )
+      
+      assert.equal(firstAttempt.success, false, 'Should soft timeout')
+      assert.ok(firstAttempt.promise, 'Should preserve first attempt promise')
+      
+      // Second attempt: starts with soft timeout at 200ms
+      // But first attempt completes at 150ms total and wins the race
+      const secondAttempt = await preserveFetchPromise(
+        url,
+        { timeout: 200 },
+        { attemptArray: [firstAttempt.promise], attemptNumber: 1, remainingTime: 400 }
+      )
+      
+      // First attempt should win because it completes at 150ms
+      // while second attempt won't complete until 200ms+
+      assert.equal(secondAttempt.success, true, 'First attempt should win')
+      assert.equal(secondAttempt.attemptNumber, 0, 'Should be from first attempt')
+    } catch (error) {
+      assert.fail(`Error was thrown: ${error.message}`)
     }
   })
 })

--- a/test/integration/retryWithPromises.test.js
+++ b/test/integration/retryWithPromises.test.js
@@ -1,0 +1,49 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert'
+import nock from 'nock'
+import { fetchWithRacedRetries } from '../../src/retry.js'
+
+const retries = 3
+const timeout = 200
+const growthFactor = 2
+const totalTimeout = 800
+const url = 'http://example.com'
+
+const mockCall = (delay = 0, responseCode = 200, count = 1) => {
+  return nock(url)
+    .get('/')
+    .delay(delay)
+    .times(count)
+    .reply(responseCode, {})
+}
+
+const options = {
+  retries,
+  timeout,
+  growthFactor,
+  totalTimeout
+}
+
+describe('fetchWithRacedRetries tests', async () => {
+  beforeEach(() => nock.cleanAll())
+  it('Check that the fetch works on the first attempt', async () => {
+    mockCall(50)
+    try {
+      const response = await fetchWithRacedRetries(url, options)
+      assert.equal(response.status, 200)
+    } catch (error) {
+      assert.fail(error.message)
+    }
+  }),
+  it('check that multiple attempts returns the one that resolves first', async () => {
+    mockCall(250, 200)
+    mockCall(200, 300)
+    try {
+      const response = await fetchWithRacedRetries(url, options)
+      assert.equal(response.status, 200)
+    } catch (error) {
+      assert.fail(error.message)
+    }
+  })
+
+})


### PR DESCRIPTION
# PR: Undgår CORS-fejl ved aborted Options Requests via Promise.race

## Beskrivelse
fetchWithRetry afbryder tidligere forespørgsler via AbortController. Dette udløser CORS‑fejl ved WMS/WMTS‑kald, hvis en preflight Options request stadig er undervejs (fx endpoints som [/map/3567](https://dataforsyningen.dk/map/3567)`). 

En ny  retry‑strategi, retryWithPromises, løser dette. I stedet for at afbryde et fetch, før der påny forsøges igen, holdes forsøg i live via Promise.race. In praksis indfører dette to timeouts
- Soft Timeout:  Ny fetch forsøges og races mod tidligere fetches
- Hård Timeout: Fetch forsøg afbrydes grundet lang svartid fra server.

Ydermere er dyanmisk timeout refaktureret til at håndtere den egentlige distribution af svartider fra api.dataforsyningen.dk.

## Ændringer
- Fil: `retry.js`
  - `preserveFetchPromise`: starter fetch med intern hard timeout (remainingTime) men returnerer enten:
    - `{ success: true, promise, attemptNumber, response }` hvis fetch fuldfører før soft timeout, eller
    - `{ success: false, promise, attemptNumber }` hvis soft timeout udløber (fetch fortsætter i baggrunden).
  - `retryPromiseAttempt`: akkumulerer rekursivt aktive fetch‑promises i `activeAttempts` og starter næste forsøg ved soft timeout. Returnerer første succesfulde response.
  - `retryWithPromises`: Wrapper med start case til rekursionen.
  - Tilføjelse af {maxTimeout, minTimeout, timeoutSignalHeuristic} til retryOptions, samt tilføjelse 

## Hvordan det virker (kort)
- Hvert forsøg starter en fetch og races mod en soft timeout (`options.timeout`).
- Hvis soft timeout udløber, gemmes den fortsættende fetchs promise i `activeAttempts`.
- Første fetch (ny eller tidligere) som fuldfører succesfuldt returneres straks.
- Hvis alle forsøg fejler, dvs. at retries er udtrømt eller hård timeout nås, udføres ```throw new Error(x)```.

-Opdateringer af dynamisk timeout sker kun hvis

1. #timeoutHeuristicSignal extends eller constractions er blevet signaleret (for at mindske cykliske mønstre)
2. responstiden er mindre end 3*timeout, for at fjerne outliers
3. den nye timeout er indenfor maxtimeout of mintimeout

Se dertil følgende graf for forklaring.

![Centroide_Gaeldende-hist](https://github.com/user-attachments/assets/b6ad61d2-21fb-4295-bdf2-89a36b26392f)
## Fordele
- Undgår CORS‑fejl forårsaget af tidlige aborter (særligt OPTIONS).
- Hurtigere succes på ustabile endpoints uden at afbryde langsomme fetches.

## Potentielle problemer
- Flere samtidige fetches øger antal åbne forbindelser- Derfor skal config af retryOptions vurderes.

## Checklist
- [ ] Unit Test (Test af retryWithPromise, retryPromiseAttempt og PreserveFetchPromise)
- [X] Feature (Dynamisk timeout med respekt til distribution af svartider fra api.dataforsyningen.dk) 
- [X] Feature (Retry med raced promises) 
- [X] JSDocs (Dokumentation af løsning) 
- [ ] QA (Gennemgang af kode med kommentarer)
